### PR TITLE
Fix panic if no fuck given, format operations output

### DIFF
--- a/cmd/fuck.go
+++ b/cmd/fuck.go
@@ -1,191 +1,197 @@
 package cmd
 
 import (
-  "fmt"
-  "github.com/palash25/foaas-cli/fucks"
-  "github.com/spf13/cobra"
+	"fmt"
+	"os"
+
+	"github.com/palash25/foaas-cli/fucks"
+	"github.com/spf13/cobra"
 )
 
 func init() {
-  fuckCmd.Flags().StringVarP(&from, "from", "f", "", "Who the fuck is this fuck from?")
-  fuckCmd.Flags().StringVarP(&company, "company", "c", "", "")
-  fuckCmd.Flags().StringVarP(&name, "name", "n", "", "")
-  fuckCmd.Flags().StringVarP(&lang, "lang", "l", "", "")
-  fuckCmd.Flags().StringVarP(&ref, "reference", "r", "", "")
-  fuckCmd.Flags().StringVarP(&react, "reaction", "", "", "")
-  fuckCmd.Flags().StringVarP(&thing, "thing", "t", "", "")
-  fuckCmd.Flags().StringVarP(&behaviour, "behaviour", "b", "", "")
-  fuckCmd.Flags().StringVarP(&tool, "tool", "", "", "")
-  fuckCmd.Flags().StringVarP(&do, "do", "d", "", "")
-  fuckCmd.Flags().StringVarP(&something, "something", "s", "", "")
-  fuckCmd.Flags().StringVarP(&noun, "noun", "", "", "")
+	fuckCmd.Flags().StringVarP(&from, "from", "f", "", "Who the fuck is this fuck from?")
+	fuckCmd.Flags().StringVarP(&company, "company", "c", "", "")
+	fuckCmd.Flags().StringVarP(&name, "name", "n", "", "")
+	fuckCmd.Flags().StringVarP(&lang, "lang", "l", "", "")
+	fuckCmd.Flags().StringVarP(&ref, "reference", "r", "", "")
+	fuckCmd.Flags().StringVarP(&react, "reaction", "", "", "")
+	fuckCmd.Flags().StringVarP(&thing, "thing", "t", "", "")
+	fuckCmd.Flags().StringVarP(&behaviour, "behaviour", "b", "", "")
+	fuckCmd.Flags().StringVarP(&tool, "tool", "", "", "")
+	fuckCmd.Flags().StringVarP(&do, "do", "d", "", "")
+	fuckCmd.Flags().StringVarP(&something, "something", "s", "", "")
+	fuckCmd.Flags().StringVarP(&noun, "noun", "", "", "")
 }
 
 var from, name, noun, lang, company, ref, react, thing, behaviour, tool, do, something string
 
 var fuckCmd = &cobra.Command{
-  Use:   "fuck",
-  Short: "Request various fucks from FOaaS",
-  Run: func(cmd *cobra.Command, args []string) {
-         switch args[0] {
-         case "asshole":
-                fmt.Println(fucks.Asshole(from))
-         case "anyway":
-                fmt.Println(fucks.Anyway(company, from))
-         case "awesome":
-                fmt.Println(fucks.Awesome(from))
-         case "back":
-                fmt.Println(fucks.Back(name, from))
-         case "bag":
-                fmt.Println(fucks.Bag(from))
-         case "ballmer":
-                fmt.Println(fucks.Ballmer(name, company, from))
-         case "bday":
-                fmt.Println(fucks.Bday(name, from))
-         case "because":
-                fmt.Println(fucks.Because(from))
-         case "blackadder":
-                fmt.Println(fucks.Blackadder(name, from))
-         case "bm":
-                fmt.Println(fucks.Bm(name, from))
-         case "bucket":
-                fmt.Println(fucks.Bucket(from))
-         case "bus":
-                fmt.Println(fucks.Bus(name, from))
-         case "bye":
-                fmt.Println(fucks.Bye(from))
-         case "caniuse":
-                fmt.Println(fucks.Caniuse(name, from))
-         case "chainsaw":
-                fmt.Println(fucks.Chainsaw(name, from))
-         case "cocksplat":
-                fmt.Println(fucks.Cocksplat(name, from))
-         case "cool":
-                fmt.Println(fucks.Cool(from))
-         case "cup":
-                fmt.Println(fucks.Cup(from))
-         case "dalton":
-                fmt.Println(fucks.Dalton(name, from))
-         case "deraadt":
-                fmt.Println(fucks.Deraadt(name, from))
-         case "diabetes":
-                fmt.Println(fucks.Diabetes(from))
-         case "donut":
-                fmt.Println(fucks.Donut(name, from))
-         case "dosomething":
-                fmt.Println(fucks.DoSomething(do, something, from))
-         case "everyone":
-                fmt.Println(fucks.Everyone(from))
-         case "everything":
-                fmt.Println(fucks.Everything(from))
-         case "family":
-                fmt.Println(fucks.Family(from))
-         case "fascinating":
-                fmt.Println(fucks.Fascinating(from))
-         case "flying":
-                fmt.Println(fucks.Flying(from))
-         case "fyyff":
-                fmt.Println(fucks.Fyyff(from))
-         case "give":
-                fmt.Println(fucks.Give(from))
-         case "field":
-                fmt.Println(fucks.Field(name, from, ref))
-         case "greed":
-                fmt.Println(fucks.Greed(noun, from))
-         case "horse":
-                fmt.Println(fucks.Horse(from))
-         case "immensity":
-                fmt.Println(fucks.Immensity(from))
-         case "ing":
-                fmt.Println(fucks.Ing(name, from))
-         case "keep":
-                fmt.Println(fucks.Keep(name, from))
-         case "keepcalm":
-                fmt.Println(fucks.KeepCalm(react, from))
-         case "king":
-                fmt.Println(fucks.King(name, from))
-         case "life":
-                fmt.Println(fucks.Life(from))
-         case "linus":
-                fmt.Println(fucks.Linus(name, from))
-         case "look":
-                fmt.Println(fucks.Look(name, from))
-         case "looking":
-                fmt.Println(fucks.Looking(from))
-         case "madison":
-                fmt.Println(fucks.Madison(name, from))
-         case "maybe":
-                fmt.Println(fucks.Maybe(from))
-         case "me":
-                fmt.Println(fucks.Me(from))
-         case "mornin":
-                fmt.Println(fucks.Mornin(from))
-         case "no":
-                fmt.Println(fucks.No(from))
-         case "nugget":
-                fmt.Println(fucks.Nugget(name, from))
-         case "off":
-                fmt.Println(fucks.Off(name, from))
-         case "offwith":
-                fmt.Println(fucks.OffWith(behaviour, from))
-         case "outside":
-                fmt.Println(fucks.Outside(name, from))
-         case "particular":
-                fmt.Println(fucks.Particular(thing, from))
-         case "pink":
-                fmt.Println(fucks.Pink(from))
-         case "problem":
-                fmt.Println(fucks.Problem(name, from))
-         case "programmer":
-                fmt.Println(fucks.Programmer(from))
-         case "pulp":
-                fmt.Println(fucks.Pulp(lang, from))
-         case "question":
-                fmt.Println(fucks.Question(ref))
-         case "retard":
-                fmt.Println(fucks.Retard(from))
-         case "ridiculous":
-                fmt.Println(fucks.Ridiculous(from))
-         case "rtfm":
-                fmt.Println(fucks.Rtfm(from))
-         case "sake":
-                fmt.Println(fucks.Sake(from))
-         case "shit":
-                fmt.Println(fucks.Shit(from))
-         case "single":
-                fmt.Println(fucks.Single(from))
-         case "thanks":
-                fmt.Println(fucks.Thanks(from))
-         case "that":
-                fmt.Println(fucks.That(from))
-         case "shakespeare":
-                fmt.Println(fucks.Shakespeare(name, from))
-         case "think":
-                fmt.Println(fucks.Think(name, from))
-         case "thinking":
-                fmt.Println(fucks.Thinking(name, from))
-         case "thumbs":
-                fmt.Println(fucks.Thumbs(name, from))
-         case "xmas":
-                fmt.Println(fucks.Xmas(name, from))
-         case "yoda":
-                fmt.Println(fucks.Yoda(name, from))
-         case "you":
-                fmt.Println(fucks.You(name, from))
-         case "this":
-                fmt.Println(fucks.This(from))
-         case "too":
-                fmt.Println(fucks.Too(from))
-         case "tucker":
-                fmt.Println(fucks.Tucker(from))
-         case "what":
-                fmt.Println(fucks.What(from))
-         case "zayn":
-                fmt.Println(fucks.Zayn(from))
-         case "zero":
-                fmt.Println(fucks.Zero(from))
-         default:
-                panic("Invalid argument")
-         }
-  },
+	Use:   "fuck",
+	Short: "Request various fucks from FOaaS",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			fmt.Printf("you need to specifiy what type of fuck to give, see %s operations for full list\n", cmd.CommandPath())
+			os.Exit(1)
+		}
+		switch args[0] {
+		case "asshole":
+			fmt.Println(fucks.Asshole(from))
+		case "anyway":
+			fmt.Println(fucks.Anyway(company, from))
+		case "awesome":
+			fmt.Println(fucks.Awesome(from))
+		case "back":
+			fmt.Println(fucks.Back(name, from))
+		case "bag":
+			fmt.Println(fucks.Bag(from))
+		case "ballmer":
+			fmt.Println(fucks.Ballmer(name, company, from))
+		case "bday":
+			fmt.Println(fucks.Bday(name, from))
+		case "because":
+			fmt.Println(fucks.Because(from))
+		case "blackadder":
+			fmt.Println(fucks.Blackadder(name, from))
+		case "bm":
+			fmt.Println(fucks.Bm(name, from))
+		case "bucket":
+			fmt.Println(fucks.Bucket(from))
+		case "bus":
+			fmt.Println(fucks.Bus(name, from))
+		case "bye":
+			fmt.Println(fucks.Bye(from))
+		case "caniuse":
+			fmt.Println(fucks.Caniuse(name, from))
+		case "chainsaw":
+			fmt.Println(fucks.Chainsaw(name, from))
+		case "cocksplat":
+			fmt.Println(fucks.Cocksplat(name, from))
+		case "cool":
+			fmt.Println(fucks.Cool(from))
+		case "cup":
+			fmt.Println(fucks.Cup(from))
+		case "dalton":
+			fmt.Println(fucks.Dalton(name, from))
+		case "deraadt":
+			fmt.Println(fucks.Deraadt(name, from))
+		case "diabetes":
+			fmt.Println(fucks.Diabetes(from))
+		case "donut":
+			fmt.Println(fucks.Donut(name, from))
+		case "dosomething":
+			fmt.Println(fucks.DoSomething(do, something, from))
+		case "everyone":
+			fmt.Println(fucks.Everyone(from))
+		case "everything":
+			fmt.Println(fucks.Everything(from))
+		case "family":
+			fmt.Println(fucks.Family(from))
+		case "fascinating":
+			fmt.Println(fucks.Fascinating(from))
+		case "flying":
+			fmt.Println(fucks.Flying(from))
+		case "fyyff":
+			fmt.Println(fucks.Fyyff(from))
+		case "give":
+			fmt.Println(fucks.Give(from))
+		case "field":
+			fmt.Println(fucks.Field(name, from, ref))
+		case "greed":
+			fmt.Println(fucks.Greed(noun, from))
+		case "horse":
+			fmt.Println(fucks.Horse(from))
+		case "immensity":
+			fmt.Println(fucks.Immensity(from))
+		case "ing":
+			fmt.Println(fucks.Ing(name, from))
+		case "keep":
+			fmt.Println(fucks.Keep(name, from))
+		case "keepcalm":
+			fmt.Println(fucks.KeepCalm(react, from))
+		case "king":
+			fmt.Println(fucks.King(name, from))
+		case "life":
+			fmt.Println(fucks.Life(from))
+		case "linus":
+			fmt.Println(fucks.Linus(name, from))
+		case "look":
+			fmt.Println(fucks.Look(name, from))
+		case "looking":
+			fmt.Println(fucks.Looking(from))
+		case "madison":
+			fmt.Println(fucks.Madison(name, from))
+		case "maybe":
+			fmt.Println(fucks.Maybe(from))
+		case "me":
+			fmt.Println(fucks.Me(from))
+		case "mornin":
+			fmt.Println(fucks.Mornin(from))
+		case "no":
+			fmt.Println(fucks.No(from))
+		case "nugget":
+			fmt.Println(fucks.Nugget(name, from))
+		case "off":
+			fmt.Println(fucks.Off(name, from))
+		case "offwith":
+			fmt.Println(fucks.OffWith(behaviour, from))
+		case "outside":
+			fmt.Println(fucks.Outside(name, from))
+		case "particular":
+			fmt.Println(fucks.Particular(thing, from))
+		case "pink":
+			fmt.Println(fucks.Pink(from))
+		case "problem":
+			fmt.Println(fucks.Problem(name, from))
+		case "programmer":
+			fmt.Println(fucks.Programmer(from))
+		case "pulp":
+			fmt.Println(fucks.Pulp(lang, from))
+		case "question":
+			fmt.Println(fucks.Question(ref))
+		case "retard":
+			fmt.Println(fucks.Retard(from))
+		case "ridiculous":
+			fmt.Println(fucks.Ridiculous(from))
+		case "rtfm":
+			fmt.Println(fucks.Rtfm(from))
+		case "sake":
+			fmt.Println(fucks.Sake(from))
+		case "shit":
+			fmt.Println(fucks.Shit(from))
+		case "single":
+			fmt.Println(fucks.Single(from))
+		case "thanks":
+			fmt.Println(fucks.Thanks(from))
+		case "that":
+			fmt.Println(fucks.That(from))
+		case "shakespeare":
+			fmt.Println(fucks.Shakespeare(name, from))
+		case "think":
+			fmt.Println(fucks.Think(name, from))
+		case "thinking":
+			fmt.Println(fucks.Thinking(name, from))
+		case "thumbs":
+			fmt.Println(fucks.Thumbs(name, from))
+		case "xmas":
+			fmt.Println(fucks.Xmas(name, from))
+		case "yoda":
+			fmt.Println(fucks.Yoda(name, from))
+		case "you":
+			fmt.Println(fucks.You(name, from))
+		case "this":
+			fmt.Println(fucks.This(from))
+		case "too":
+			fmt.Println(fucks.Too(from))
+		case "tucker":
+			fmt.Println(fucks.Tucker(from))
+		case "what":
+			fmt.Println(fucks.What(from))
+		case "zayn":
+			fmt.Println(fucks.Zayn(from))
+		case "zero":
+			fmt.Println(fucks.Zero(from))
+		default:
+			panic("Invalid argument")
+		}
+	},
 }

--- a/cmd/fuck.go
+++ b/cmd/fuck.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/palash25/foaas-cli/fucks"
 	"github.com/spf13/cobra"
@@ -30,7 +31,7 @@ var fuckCmd = &cobra.Command{
 	Short: "Request various fucks from FOaaS",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Printf("you need to specifiy what type of fuck to give, see \"%s operations\" for full list\n", os.Args[0])
+			fmt.Printf("you need to specifiy what type of fuck to give, see \"%s operations\" for full list\n", path.Base(os.Args[0]))
 			os.Exit(1)
 		}
 		switch args[0] {

--- a/cmd/fuck.go
+++ b/cmd/fuck.go
@@ -30,7 +30,7 @@ var fuckCmd = &cobra.Command{
 	Short: "Request various fucks from FOaaS",
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
-			fmt.Printf("you need to specifiy what type of fuck to give, see %s operations for full list\n", cmd.CommandPath())
+			fmt.Printf("you need to specifiy what type of fuck to give, see \"%s operations\" for full list\n", os.Args[0])
 			os.Exit(1)
 		}
 		switch args[0] {

--- a/cmd/operations.go
+++ b/cmd/operations.go
@@ -1,16 +1,38 @@
 package cmd
 
 import (
-  "fmt"
-  "github.com/palash25/foaas-cli/fucks"
-  "github.com/spf13/cobra"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/palash25/foaas-cli/fucks"
+	"github.com/spf13/cobra"
 )
 
+type operation struct {
+	Name   string            `json:"name"`
+	URL    string            `json:"url"`
+	Fields []operationFields `json:"fields"`
+}
+
+type operationFields struct {
+	Name  string `json:"name"`
+	Field string `json:"field"`
+}
+
 var operationsCmd = &cobra.Command{
-  Use:   "operations",
-  Short: "Print the operations of FOaaS",
-  Run: func(cmd *cobra.Command, args []string) {
-    ops := fucks.GetOperations()
-    fmt.Println(ops)
-  },
+	Use:   "operations",
+	Short: "Print the operations of FOaaS",
+	Run: func(cmd *cobra.Command, args []string) {
+		ops := fucks.GetOperations()
+		var opsList []operation
+		if err := json.Unmarshal([]byte(ops), &opsList); err != nil {
+			fmt.Println("failed to parse list of fucks")
+			os.Exit(1)
+		}
+
+		for i := range opsList {
+			fmt.Println(opsList[i].Name)
+		}
+	},
 }

--- a/cmd/operations.go
+++ b/cmd/operations.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/palash25/foaas-cli/fucks"
 	"github.com/spf13/cobra"
@@ -31,8 +32,14 @@ var operationsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
+		var out string
 		for i := range opsList {
-			fmt.Println(opsList[i].Name)
+			var fields []string
+			for b := range opsList[i].Fields {
+				fields = append(fields, opsList[i].Fields[b].Field)
+			}
+			out = fmt.Sprintf("%s - %s", strings.ToLower(opsList[i].Name), strings.Join(fields, ", "))
+			fmt.Println(out)
 		}
 	},
 }


### PR DESCRIPTION
This pull request fixes `foaas-cli` so that if ran with no arguments to `fuck` subcommand it no longer panics with an index out of bounds error.

```
[~]─> foaas-cli fuck
you need to specifiy what type of fuck to give, see "/home/vendion/gocode/bin/foaas-cli operations" for full list
```

This also formats the output from `foaas-cli operations` so it just doesn't dump JSON to STDOUT, making it easier to read.

```
[~]─> foaas-cli operations
Who the fuck are you anyway
Asshole
Awesome
Back the fuck off
Bag
Ballmer
Bday
Because
Blackadder
Bravo Mike
Bucket
Bus
Bye
Can I Use
Chainsaw
...
```

This also brings _cmd/fuck.go_ and _cmd/operations.go_ to meet the Go style guide of running (ie running gofmt or goimports)